### PR TITLE
create sub-resource + test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ariga/ogent
 go 1.17
 
 require (
-	entgo.io/contrib v0.2.1-0.20220104125732-5255cb0729b5
+	entgo.io/contrib v0.2.1-0.20220105104216-0541a2d16b0d
 	entgo.io/ent v0.9.2-0.20211220092907-4d01a56b8de7
 	github.com/go-faster/errors v0.5.0
 	github.com/go-faster/jx v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,10 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 entgo.io/contrib v0.2.1-0.20220104125732-5255cb0729b5 h1:3ZoFI9uu/01I1dlk9jCPRsN+qQX45FKr2eYqK6lJsio=
 entgo.io/contrib v0.2.1-0.20220104125732-5255cb0729b5/go.mod h1:GHmU7qbKeth0bPkojXIJMottaQAkTQ7gntVv/syDH+Y=
+entgo.io/contrib v0.2.1-0.20220105080149-0b129f189d21 h1:Gf95SRzXD+UfAmV8SaXERxtKYvVz/N2EHmG3IYnA7vk=
+entgo.io/contrib v0.2.1-0.20220105080149-0b129f189d21/go.mod h1:GHmU7qbKeth0bPkojXIJMottaQAkTQ7gntVv/syDH+Y=
+entgo.io/contrib v0.2.1-0.20220105104216-0541a2d16b0d h1:qCJt3Js1/4z4JVR/xS3Aoymonz+8KDwyoe4Eiw/AMt0=
+entgo.io/contrib v0.2.1-0.20220105104216-0541a2d16b0d/go.mod h1:GHmU7qbKeth0bPkojXIJMottaQAkTQ7gntVv/syDH+Y=
 entgo.io/ent v0.9.2-0.20211220092907-4d01a56b8de7 h1:v5R9L5IE4fakNcs5OlNKFZ5Cn0Oa6ogs2o8qmHSWO4Y=
 entgo.io/ent v0.9.2-0.20211220092907-4d01a56b8de7/go.mod h1:9jjnWS3pUqkDkRXYHkMU3nZlrj9enQJgIeImJyCm0sc=
 github.com/99designs/gqlgen v0.14.0/go.mod h1:S7z4boV+Nx4VvzMUpVrY/YuHjFX4n7rDyuTqvAkuoRE=

--- a/internal/integration/ogent/ent/ogent/oas_res_dec_gen.go
+++ b/internal/integration/ogent/ent/ogent/oas_res_dec_gen.go
@@ -233,6 +233,33 @@ func decodeCreateCategoryPetsResponse(resp *http.Response, span trace.Span) (res
 		default:
 			return res, errors.Errorf("unexpected content-type: %s", resp.Header.Get("Content-Type"))
 		}
+	case 404:
+		switch resp.Header.Get("Content-Type") {
+		case "application/json":
+			buf := getBuf()
+			defer putBuf(buf)
+			if _, err := io.Copy(buf, resp.Body); err != nil {
+				return res, err
+			}
+
+			d := jx.GetDecoder()
+			defer jx.PutDecoder(d)
+			d.ResetBytes(buf.Bytes())
+
+			var response R404
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return res, err
+			}
+
+			return &response, nil
+		default:
+			return res, errors.Errorf("unexpected content-type: %s", resp.Header.Get("Content-Type"))
+		}
 	case 409:
 		switch resp.Header.Get("Content-Type") {
 		case "application/json":
@@ -463,6 +490,33 @@ func decodeCreatePetCategoriesResponse(resp *http.Response, span trace.Span) (re
 		default:
 			return res, errors.Errorf("unexpected content-type: %s", resp.Header.Get("Content-Type"))
 		}
+	case 404:
+		switch resp.Header.Get("Content-Type") {
+		case "application/json":
+			buf := getBuf()
+			defer putBuf(buf)
+			if _, err := io.Copy(buf, resp.Body); err != nil {
+				return res, err
+			}
+
+			d := jx.GetDecoder()
+			defer jx.PutDecoder(d)
+			d.ResetBytes(buf.Bytes())
+
+			var response R404
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return res, err
+			}
+
+			return &response, nil
+		default:
+			return res, errors.Errorf("unexpected content-type: %s", resp.Header.Get("Content-Type"))
+		}
 	case 409:
 		switch resp.Header.Get("Content-Type") {
 		case "application/json":
@@ -578,6 +632,33 @@ func decodeCreatePetFriendsResponse(resp *http.Response, span trace.Span) (res C
 		default:
 			return res, errors.Errorf("unexpected content-type: %s", resp.Header.Get("Content-Type"))
 		}
+	case 404:
+		switch resp.Header.Get("Content-Type") {
+		case "application/json":
+			buf := getBuf()
+			defer putBuf(buf)
+			if _, err := io.Copy(buf, resp.Body); err != nil {
+				return res, err
+			}
+
+			d := jx.GetDecoder()
+			defer jx.PutDecoder(d)
+			d.ResetBytes(buf.Bytes())
+
+			var response R404
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return res, err
+			}
+
+			return &response, nil
+		default:
+			return res, errors.Errorf("unexpected content-type: %s", resp.Header.Get("Content-Type"))
+		}
 	case 409:
 		switch resp.Header.Get("Content-Type") {
 		case "application/json":
@@ -680,6 +761,33 @@ func decodeCreatePetOwnerResponse(resp *http.Response, span trace.Span) (res Cre
 			d.ResetBytes(buf.Bytes())
 
 			var response R400
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return res, err
+			}
+
+			return &response, nil
+		default:
+			return res, errors.Errorf("unexpected content-type: %s", resp.Header.Get("Content-Type"))
+		}
+	case 404:
+		switch resp.Header.Get("Content-Type") {
+		case "application/json":
+			buf := getBuf()
+			defer putBuf(buf)
+			if _, err := io.Copy(buf, resp.Body); err != nil {
+				return res, err
+			}
+
+			d := jx.GetDecoder()
+			defer jx.PutDecoder(d)
+			d.ResetBytes(buf.Bytes())
+
+			var response R404
 			if err := func() error {
 				if err := response.Decode(d); err != nil {
 					return err
@@ -910,6 +1018,33 @@ func decodeCreateUserPetsResponse(resp *http.Response, span trace.Span) (res Cre
 			d.ResetBytes(buf.Bytes())
 
 			var response R400
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return res, err
+			}
+
+			return &response, nil
+		default:
+			return res, errors.Errorf("unexpected content-type: %s", resp.Header.Get("Content-Type"))
+		}
+	case 404:
+		switch resp.Header.Get("Content-Type") {
+		case "application/json":
+			buf := getBuf()
+			defer putBuf(buf)
+			if _, err := io.Copy(buf, resp.Body); err != nil {
+				return res, err
+			}
+
+			d := jx.GetDecoder()
+			defer jx.PutDecoder(d)
+			d.ResetBytes(buf.Bytes())
+
+			var response R404
 			if err := func() error {
 				if err := response.Decode(d); err != nil {
 					return err

--- a/internal/integration/ogent/ent/ogent/oas_res_enc_gen.go
+++ b/internal/integration/ogent/ent/ogent/oas_res_enc_gen.go
@@ -143,6 +143,18 @@ func encodeCreateCategoryPetsResponse(response CreateCategoryPetsRes, w http.Res
 		}
 
 		return nil
+	case *R404:
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(404)
+		e := jx.GetEncoder()
+		defer jx.PutEncoder(e)
+
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
 	case *R409:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(409)
@@ -253,6 +265,18 @@ func encodeCreatePetCategoriesResponse(response CreatePetCategoriesRes, w http.R
 		}
 
 		return nil
+	case *R404:
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(404)
+		e := jx.GetEncoder()
+		defer jx.PutEncoder(e)
+
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
 	case *R409:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(409)
@@ -308,6 +332,18 @@ func encodeCreatePetFriendsResponse(response CreatePetFriendsRes, w http.Respons
 		}
 
 		return nil
+	case *R404:
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(404)
+		e := jx.GetEncoder()
+		defer jx.PutEncoder(e)
+
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
 	case *R409:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(409)
@@ -354,6 +390,18 @@ func encodeCreatePetOwnerResponse(response CreatePetOwnerRes, w http.ResponseWri
 	case *R400:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		e := jx.GetEncoder()
+		defer jx.PutEncoder(e)
+
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+	case *R404:
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(404)
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 
@@ -464,6 +512,18 @@ func encodeCreateUserPetsResponse(response CreateUserPetsRes, w http.ResponseWri
 	case *R400:
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(400)
+		e := jx.GetEncoder()
+		defer jx.PutEncoder(e)
+
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+	case *R404:
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(404)
 		e := jx.GetEncoder()
 		defer jx.PutEncoder(e)
 

--- a/internal/integration/ogent/ent/ogent/oas_schemas_gen.go
+++ b/internal/integration/ogent/ent/ogent/oas_schemas_gen.go
@@ -542,24 +542,29 @@ type R404 struct {
 	Errors OptString `json:"errors"`
 }
 
-func (*R404) deleteCategoryRes()    {}
-func (*R404) deletePetOwnerRes()    {}
-func (*R404) deletePetRes()         {}
-func (*R404) deleteUserRes()        {}
-func (*R404) listCategoryPetsRes()  {}
-func (*R404) listCategoryRes()      {}
-func (*R404) listPetCategoriesRes() {}
-func (*R404) listPetFriendsRes()    {}
-func (*R404) listPetRes()           {}
-func (*R404) listUserPetsRes()      {}
-func (*R404) listUserRes()          {}
-func (*R404) readCategoryRes()      {}
-func (*R404) readPetOwnerRes()      {}
-func (*R404) readPetRes()           {}
-func (*R404) readUserRes()          {}
-func (*R404) updateCategoryRes()    {}
-func (*R404) updatePetRes()         {}
-func (*R404) updateUserRes()        {}
+func (*R404) createCategoryPetsRes()  {}
+func (*R404) createPetCategoriesRes() {}
+func (*R404) createPetFriendsRes()    {}
+func (*R404) createPetOwnerRes()      {}
+func (*R404) createUserPetsRes()      {}
+func (*R404) deleteCategoryRes()      {}
+func (*R404) deletePetOwnerRes()      {}
+func (*R404) deletePetRes()           {}
+func (*R404) deleteUserRes()          {}
+func (*R404) listCategoryPetsRes()    {}
+func (*R404) listCategoryRes()        {}
+func (*R404) listPetCategoriesRes()   {}
+func (*R404) listPetFriendsRes()      {}
+func (*R404) listPetRes()             {}
+func (*R404) listUserPetsRes()        {}
+func (*R404) listUserRes()            {}
+func (*R404) readCategoryRes()        {}
+func (*R404) readPetOwnerRes()        {}
+func (*R404) readPetRes()             {}
+func (*R404) readUserRes()            {}
+func (*R404) updateCategoryRes()      {}
+func (*R404) updatePetRes()           {}
+func (*R404) updateUserRes()          {}
 
 type R409 struct {
 	Code   int       `json:"code"`

--- a/internal/integration/ogent/ent/openapi.json
+++ b/internal/integration/ogent/ent/openapi.json
@@ -400,6 +400,9 @@
           "400": {
             "$ref": "#/components/responses/400"
           },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
           "409": {
             "$ref": "#/components/responses/409"
           },
@@ -819,6 +822,9 @@
           "400": {
             "$ref": "#/components/responses/400"
           },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
           "409": {
             "$ref": "#/components/responses/409"
           },
@@ -967,6 +973,9 @@
           "400": {
             "$ref": "#/components/responses/400"
           },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
           "409": {
             "$ref": "#/components/responses/409"
           },
@@ -1080,6 +1089,9 @@
           },
           "400": {
             "$ref": "#/components/responses/400"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
           },
           "409": {
             "$ref": "#/components/responses/409"
@@ -1526,6 +1538,9 @@
           },
           "400": {
             "$ref": "#/components/responses/400"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
           },
           "409": {
             "$ref": "#/components/responses/409"

--- a/template.go
+++ b/template.go
@@ -21,6 +21,7 @@ var (
 	FuncMap = template.FuncMap{
 		"eagerLoad":      eagerLoad,
 		"edgeOperations": entoas.EdgeOperations,
+		"edgeViewName":   entoas.EdgeViewName,
 		"hasParams":      hasParams,
 		"hasRequestBody": hasRequestBody,
 		"httpVerb":       httpVerb,

--- a/template/create.tmpl
+++ b/template/create.tmpl
@@ -1,49 +1,99 @@
-{{/* gotype: entgo.io/ent/entc/gen.Type */}}
-
-{{ define "ogent/ogent/helper/create" }}
-b := h.client.{{ $.Name }}.Create()
-// Add all fields.
-{{- range $f := $.Fields }}
-	{{- if $f.Optional }}
-		if v, ok := req.{{ $f.StructField}}.Get(); ok {
-			b.Set{{ $f.StructField }}(v)
-		}
-	{{- else }}
-		b.Set{{ $f.StructField }}(req.{{ $f.StructField }})
+{{ define "ogent/ogent/helper/create" }}{{/* gotype: entgo.io/ent/entc/gen.Type */}}
+	b := h.client.{{ $.Name }}.Create()
+	{{- template  "ogent/ogent/helper/create/helper" $ -}}
+	// Persist to storage.
+	e, err := b.Save(ctx)
+	{{-
+		template "ogent/ogent/helper/error"
+		extend $
+		"Errors" (list "not-singular" "constraint")
+	-}}
+	// Reload the entity to attach all eager-loaded edges.
+	q := h.client.{{ $.Name }}.Query().Where({{ $.Package }}.ID(e.{{ $.ID.StructField }}))
+	{{- with eagerLoad $ "create" }}
+		// Eager load edges that are required on create operation.
+		q{{ . }}
 	{{- end }}
+	e, err = q.Only(ctx)
+	if err != nil {
+		// This should never happen.
+		return nil, err
+	}
+	return New{{ viewName $ "create"  }}(e), nil
 {{- end }}
-// Add all edges.
-{{- range $e := $.Edges }}
-	{{- if not $e.Unique }}
-		b.{{ $e.MutationAdd }}(req.{{ $e.StructField }}...)
-	{{- else }}
-		{{- if $e.Optional }}
-			if v, ok := req.{{ $e.StructField }}.Get(); ok {
-				b.{{ $e.MutationSet }}(v)
+
+
+{{ define "ogent/ogent/helper/create/sub" }}{{/* gotype: entgo.io/ent/entc/gen.typeScope */}}
+	// Start a transaction since we do multiple operations on the DB.
+	tx, err := h.client.Tx(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// Fetch the {{ $.Type.Name }} to attach the {{ $.Scope.Edge.Type.Name }} to.
+	p, err := tx.{{ $.Type.Name }}.Get(ctx, params.{{ $.Type.ID.StructField }})
+	{{-
+		template "ogent/ogent/helper/error"
+		extend $
+		"Errors" (list "not-found" "not-singular")
+		"Tx" "tx"
+	-}}
+	// Create the {{ $.Scope.Edge.Type.Name }} to attach.
+	b := tx.{{ $.Scope.Edge.Type.Name }}.Create()
+	{{- template  "ogent/ogent/helper/create/helper" $.Scope.Edge.Type -}}
+	e, err := b.Save(ctx)
+	{{-
+		template "ogent/ogent/helper/error"
+		extend $
+		"Errors" (list "not-singular" "constraint")
+		"Tx" "tx"
+	-}}
+	_, err = p.Update().{{ if $.Scope.Edge.Unique }}{{ $.Scope.Edge.MutationSet }}{{ else }}{{ $.Scope.Edge.MutationAdd }}{{ end }}(e.{{ $.Scope.Edge.Type.ID.StructField}}).Save(ctx)
+	{{-
+		template "ogent/ogent/helper/error"
+		extend $
+		"Errors" (list "constraint")
+		"Tx" "tx"
+	-}}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	// Reload the entity to attach all eager-loaded edges.
+	q := h.client.{{ $.Scope.Edge.Type.Name }}.Query().Where({{ $.Scope.Edge.Type.Package }}.ID(params.{{ $.Type.ID.StructField }}))
+	{{- with eagerLoad $.Scope.Edge.Type "create" }}
+		// Eager load edges that are required on create operation.
+		q{{ . }}
+	{{- end }}
+	e, err = q.Only(ctx)
+	if err != nil {
+		// This should never happen.
+		return nil, err
+	}
+	return New{{ replaceAll (edgeViewName $.Type $.Scope.Edge "create") "_" "" }}(e), nil
+{{- end }}
+
+{{ define "ogent/ogent/helper/create/helper" }}{{/* gotype: entgo.io/ent/entc/gen.Type */}}
+	// Add all fields.
+	{{- range $f := $.Fields }}
+		{{- if $f.Optional }}
+			if v, ok := req.{{ $f.StructField}}.Get(); ok {
+				b.Set{{ $f.StructField }}(v)
 			}
 		{{- else }}
-				b.{{ $e.MutationSet }}(req.{{ $e.StructField }})
+			b.Set{{ $f.StructField }}(req.{{ $f.StructField }})
 		{{- end }}
 	{{- end }}
-{{- end }}
-// Persist to storage.
-e, err := b.Save(ctx)
-{{-
-	template "ogent/ogent/helper/error"
-	extend $
-	"Errors" (list "not-singular" "constraint")
--}}
-// Reload the entity to attach all eager-loaded edges.
-q := h.client.{{ $.Name }}.Query().Where({{ $.Name | lower }}.ID(e.{{ $.ID.StructField }}))
-{{- with eagerLoad $ "create" }}
-	// Eager load edges that are required on create operation.
-	q{{ . }}
-{{- end }}
-e, err = q.Only(ctx)
-if err != nil {
-	// This should never happen.
-	return nil, err
-}
-return New{{ viewName $ "create"  }}(e), nil
-{{- end }}
-
+	// Add all edges.
+	{{- range $e := $.Edges }}
+		{{- if not $e.Unique }}
+			b.{{ $e.MutationAdd }}(req.{{ $e.StructField }}...)
+		{{- else }}
+			{{- if $e.Optional }}
+				if v, ok := req.{{ $e.StructField }}.Get(); ok {
+					b.{{ $e.MutationSet }}(v)
+				}
+			{{- else }}
+				b.{{ $e.MutationSet }}(req.{{ $e.StructField }})
+			{{- end }}
+		{{- end }}
+	{{- end }}
+{{ end }}

--- a/template/error.tmpl
+++ b/template/error.tmpl
@@ -1,6 +1,11 @@
 {{ define "ogent/ogent/helper/error" }}{{/* gotype: entgo.io/ent/entc/gen.typeScope */}}
 {{- $pkg := base $.Type.Config.Package }}
 if err != nil {
+	{{- with $.Scope.Tx }}
+		if rErr := {{ . }}.Rollback(); rErr != nil {
+			return nil, fmt.Errorf("%w: %v", err, rErr)
+		}
+	{{- end }}
 	switch {
 	{{- range $err := $.Scope.Errors }}
 		{{- if eq $err "constraint" }}

--- a/template/handler.tmpl
+++ b/template/handler.tmpl
@@ -48,7 +48,17 @@ func NewOgentHandler(c *{{ $pkg }}.Client) *OgentHandler { return &OgentHandler{
 			// {{ $opID }} handles {{ httpVerb $op }} {{ printf "%s/{id}/%s" $root ($e.Name | kebab) }} requests.
 			func (h *OgentHandler) {{ $opID }}(ctx context.Context
 				{{- if hasRequestBody $op }}, req {{ $opID }}Req{{ end }}, params {{ $opID }}Params) ({{ $opID }}Res, error) {
-				panic("unimplemented")
+				{{- if isCreate $op }}
+					{{- template "ogent/ogent/helper/create/sub" extend $n "Edge" $e -}}
+				{{/*{{- else if isRead $op }}
+					{{- template "ogent/ogent/helper/read" $n -}}
+				{{- else if isUpdate $op }}
+					{{- template "ogent/ogent/helper/update" $n -}}
+				{{- else if isDelete $op }}
+					{{- template "ogent/ogent/helper/delete" $n -}}*/}}
+				{{- else }}
+					panic("unimplemented")
+				{{- end }}
 			}
 		{{ end }}
 	{{ end }}

--- a/template/update.tmpl
+++ b/template/update.tmpl
@@ -28,7 +28,7 @@ e, err := b.Save(ctx)
 	"Errors" (list "not-found" "constraint")
 -}}
 // Reload the entity to attach all eager-loaded edges.
-q := h.client.{{ $.Name }}.Query().Where({{ $.Name | lower }}.ID(e.{{ $.ID.StructField }}))
+q := h.client.{{ $.Name }}.Query().Where({{ $.Package }}.ID(e.{{ $.ID.StructField }}))
 {{- with eagerLoad $ "update" }}
 	// Eager load edges that are required on update operation.
 	q{{ . }}


### PR DESCRIPTION
This PR adds the `ogen.Handler` implementation code generator for create operations on a 1st level sub-resource. Basically it handles requests like:

`POST /pets/1/toys` 

which would create a new `Toy` resource and attaches it to the `Pet` with ID 1.