### PR TITLE
Added two new features to filter and sort a list of models.

### DIFF
--- a/extension.go
+++ b/extension.go
@@ -21,6 +21,8 @@ type (
 		Target string
 		// The Views created by entoas.
 		Views map[string]*entoas.View
+		//Enable the ogent security policy support
+		PolicySupport bool
 	}
 	// Extension implements entc.Extension interface providing integration with ogen.
 	Extension struct {
@@ -46,6 +48,14 @@ func NewExtension(spec *ogen.Spec, opts ...ExtensionOption) (*Extension, error) 
 		}
 	}
 	return ex, nil
+}
+
+// EnablePolicySupport sets the ogent security policy support
+func EnablePolicySupport() ExtensionOption {
+	return func(ex *Extension) error {
+		ex.cfg.PolicySupport = true
+		return nil
+	}
 }
 
 // Target sets the directory the ogen assets are written to.

--- a/internal/integration/ogent/ent/ogent/oas_client_gen.go
+++ b/internal/integration/ogent/ent/ogent/oas_client_gen.go
@@ -524,6 +524,38 @@ func (c *Client) ListCategory(ctx context.Context, params ListCategoryParams) (r
 		}
 		q["itemsPerPage"] = e.Result()
 	}
+	{
+		// Encode "orderBy" parameter.
+		e := uri.NewQueryEncoder(uri.QueryEncoderConfig{
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		})
+		if err := func() error {
+			if val, ok := params.OrderBy.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}(); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+		q["orderBy"] = e.Result()
+	}
+	{
+		// Encode "filter" parameter.
+		e := uri.NewQueryEncoder(uri.QueryEncoderConfig{
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		})
+		if err := func() error {
+			if val, ok := params.Filter.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}(); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+		q["filter"] = e.Result()
+	}
 	u.RawQuery = q.Encode()
 
 	r := ht.NewRequest(ctx, "GET", u, nil)
@@ -619,6 +651,38 @@ func (c *Client) ListCategoryPets(ctx context.Context, params ListCategoryPetsPa
 		}
 		q["itemsPerPage"] = e.Result()
 	}
+	{
+		// Encode "orderBy" parameter.
+		e := uri.NewQueryEncoder(uri.QueryEncoderConfig{
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		})
+		if err := func() error {
+			if val, ok := params.OrderBy.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}(); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+		q["orderBy"] = e.Result()
+	}
+	{
+		// Encode "filter" parameter.
+		e := uri.NewQueryEncoder(uri.QueryEncoderConfig{
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		})
+		if err := func() error {
+			if val, ok := params.Filter.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}(); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+		q["filter"] = e.Result()
+	}
 	u.RawQuery = q.Encode()
 
 	r := ht.NewRequest(ctx, "GET", u, nil)
@@ -698,6 +762,38 @@ func (c *Client) ListPet(ctx context.Context, params ListPetParams) (res ListPet
 			return res, errors.Wrap(err, "encode query")
 		}
 		q["itemsPerPage"] = e.Result()
+	}
+	{
+		// Encode "orderBy" parameter.
+		e := uri.NewQueryEncoder(uri.QueryEncoderConfig{
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		})
+		if err := func() error {
+			if val, ok := params.OrderBy.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}(); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+		q["orderBy"] = e.Result()
+	}
+	{
+		// Encode "filter" parameter.
+		e := uri.NewQueryEncoder(uri.QueryEncoderConfig{
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		})
+		if err := func() error {
+			if val, ok := params.Filter.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}(); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+		q["filter"] = e.Result()
 	}
 	u.RawQuery = q.Encode()
 
@@ -794,6 +890,38 @@ func (c *Client) ListPetCategories(ctx context.Context, params ListPetCategories
 		}
 		q["itemsPerPage"] = e.Result()
 	}
+	{
+		// Encode "orderBy" parameter.
+		e := uri.NewQueryEncoder(uri.QueryEncoderConfig{
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		})
+		if err := func() error {
+			if val, ok := params.OrderBy.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}(); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+		q["orderBy"] = e.Result()
+	}
+	{
+		// Encode "filter" parameter.
+		e := uri.NewQueryEncoder(uri.QueryEncoderConfig{
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		})
+		if err := func() error {
+			if val, ok := params.Filter.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}(); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+		q["filter"] = e.Result()
+	}
 	u.RawQuery = q.Encode()
 
 	r := ht.NewRequest(ctx, "GET", u, nil)
@@ -889,6 +1017,38 @@ func (c *Client) ListPetFriends(ctx context.Context, params ListPetFriendsParams
 		}
 		q["itemsPerPage"] = e.Result()
 	}
+	{
+		// Encode "orderBy" parameter.
+		e := uri.NewQueryEncoder(uri.QueryEncoderConfig{
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		})
+		if err := func() error {
+			if val, ok := params.OrderBy.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}(); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+		q["orderBy"] = e.Result()
+	}
+	{
+		// Encode "filter" parameter.
+		e := uri.NewQueryEncoder(uri.QueryEncoderConfig{
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		})
+		if err := func() error {
+			if val, ok := params.Filter.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}(); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+		q["filter"] = e.Result()
+	}
 	u.RawQuery = q.Encode()
 
 	r := ht.NewRequest(ctx, "GET", u, nil)
@@ -968,6 +1128,38 @@ func (c *Client) ListUser(ctx context.Context, params ListUserParams) (res ListU
 			return res, errors.Wrap(err, "encode query")
 		}
 		q["itemsPerPage"] = e.Result()
+	}
+	{
+		// Encode "orderBy" parameter.
+		e := uri.NewQueryEncoder(uri.QueryEncoderConfig{
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		})
+		if err := func() error {
+			if val, ok := params.OrderBy.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}(); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+		q["orderBy"] = e.Result()
+	}
+	{
+		// Encode "filter" parameter.
+		e := uri.NewQueryEncoder(uri.QueryEncoderConfig{
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		})
+		if err := func() error {
+			if val, ok := params.Filter.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}(); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+		q["filter"] = e.Result()
 	}
 	u.RawQuery = q.Encode()
 
@@ -1063,6 +1255,38 @@ func (c *Client) ListUserPets(ctx context.Context, params ListUserPetsParams) (r
 			return res, errors.Wrap(err, "encode query")
 		}
 		q["itemsPerPage"] = e.Result()
+	}
+	{
+		// Encode "orderBy" parameter.
+		e := uri.NewQueryEncoder(uri.QueryEncoderConfig{
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		})
+		if err := func() error {
+			if val, ok := params.OrderBy.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}(); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+		q["orderBy"] = e.Result()
+	}
+	{
+		// Encode "filter" parameter.
+		e := uri.NewQueryEncoder(uri.QueryEncoderConfig{
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		})
+		if err := func() error {
+			if val, ok := params.Filter.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}(); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+		q["filter"] = e.Result()
 	}
 	u.RawQuery = q.Encode()
 

--- a/internal/integration/ogent/ent/ogent/oas_param_dec_gen.go
+++ b/internal/integration/ogent/ent/ogent/oas_param_dec_gen.go
@@ -259,6 +259,76 @@ func decodeListCategoryParams(args [0]string, r *http.Request) (ListCategoryPara
 			}
 		}
 	}
+	// Decode query: orderBy.
+	{
+		values, ok := queryArgs["orderBy"]
+		if ok {
+			d := uri.NewQueryDecoder(uri.QueryDecoderConfig{
+				Values:  values,
+				Style:   uri.QueryStyleForm,
+				Explode: true,
+			})
+
+			if err := func() error {
+				var paramsDotOrderByVal string
+				if err := func() error {
+					s, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(s)
+					if err != nil {
+						return err
+					}
+
+					paramsDotOrderByVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.OrderBy.SetTo(paramsDotOrderByVal)
+				return nil
+			}(); err != nil {
+				return params, errors.Wrap(err, "query: orderBy: parse")
+			}
+		}
+	}
+	// Decode query: filter.
+	{
+		values, ok := queryArgs["filter"]
+		if ok {
+			d := uri.NewQueryDecoder(uri.QueryDecoderConfig{
+				Values:  values,
+				Style:   uri.QueryStyleForm,
+				Explode: true,
+			})
+
+			if err := func() error {
+				var paramsDotFilterVal string
+				if err := func() error {
+					s, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(s)
+					if err != nil {
+						return err
+					}
+
+					paramsDotFilterVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.Filter.SetTo(paramsDotFilterVal)
+				return nil
+			}(); err != nil {
+				return params, errors.Wrap(err, "query: filter: parse")
+			}
+		}
+	}
 	return params, nil
 }
 
@@ -368,6 +438,76 @@ func decodeListCategoryPetsParams(args [1]string, r *http.Request) (ListCategory
 			}
 		}
 	}
+	// Decode query: orderBy.
+	{
+		values, ok := queryArgs["orderBy"]
+		if ok {
+			d := uri.NewQueryDecoder(uri.QueryDecoderConfig{
+				Values:  values,
+				Style:   uri.QueryStyleForm,
+				Explode: true,
+			})
+
+			if err := func() error {
+				var paramsDotOrderByVal string
+				if err := func() error {
+					s, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(s)
+					if err != nil {
+						return err
+					}
+
+					paramsDotOrderByVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.OrderBy.SetTo(paramsDotOrderByVal)
+				return nil
+			}(); err != nil {
+				return params, errors.Wrap(err, "query: orderBy: parse")
+			}
+		}
+	}
+	// Decode query: filter.
+	{
+		values, ok := queryArgs["filter"]
+		if ok {
+			d := uri.NewQueryDecoder(uri.QueryDecoderConfig{
+				Values:  values,
+				Style:   uri.QueryStyleForm,
+				Explode: true,
+			})
+
+			if err := func() error {
+				var paramsDotFilterVal string
+				if err := func() error {
+					s, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(s)
+					if err != nil {
+						return err
+					}
+
+					paramsDotFilterVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.Filter.SetTo(paramsDotFilterVal)
+				return nil
+			}(); err != nil {
+				return params, errors.Wrap(err, "query: filter: parse")
+			}
+		}
+	}
 	return params, nil
 }
 
@@ -443,6 +583,76 @@ func decodeListPetParams(args [0]string, r *http.Request) (ListPetParams, error)
 				return nil
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: itemsPerPage: parse")
+			}
+		}
+	}
+	// Decode query: orderBy.
+	{
+		values, ok := queryArgs["orderBy"]
+		if ok {
+			d := uri.NewQueryDecoder(uri.QueryDecoderConfig{
+				Values:  values,
+				Style:   uri.QueryStyleForm,
+				Explode: true,
+			})
+
+			if err := func() error {
+				var paramsDotOrderByVal string
+				if err := func() error {
+					s, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(s)
+					if err != nil {
+						return err
+					}
+
+					paramsDotOrderByVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.OrderBy.SetTo(paramsDotOrderByVal)
+				return nil
+			}(); err != nil {
+				return params, errors.Wrap(err, "query: orderBy: parse")
+			}
+		}
+	}
+	// Decode query: filter.
+	{
+		values, ok := queryArgs["filter"]
+		if ok {
+			d := uri.NewQueryDecoder(uri.QueryDecoderConfig{
+				Values:  values,
+				Style:   uri.QueryStyleForm,
+				Explode: true,
+			})
+
+			if err := func() error {
+				var paramsDotFilterVal string
+				if err := func() error {
+					s, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(s)
+					if err != nil {
+						return err
+					}
+
+					paramsDotFilterVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.Filter.SetTo(paramsDotFilterVal)
+				return nil
+			}(); err != nil {
+				return params, errors.Wrap(err, "query: filter: parse")
 			}
 		}
 	}
@@ -555,6 +765,76 @@ func decodeListPetCategoriesParams(args [1]string, r *http.Request) (ListPetCate
 			}
 		}
 	}
+	// Decode query: orderBy.
+	{
+		values, ok := queryArgs["orderBy"]
+		if ok {
+			d := uri.NewQueryDecoder(uri.QueryDecoderConfig{
+				Values:  values,
+				Style:   uri.QueryStyleForm,
+				Explode: true,
+			})
+
+			if err := func() error {
+				var paramsDotOrderByVal string
+				if err := func() error {
+					s, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(s)
+					if err != nil {
+						return err
+					}
+
+					paramsDotOrderByVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.OrderBy.SetTo(paramsDotOrderByVal)
+				return nil
+			}(); err != nil {
+				return params, errors.Wrap(err, "query: orderBy: parse")
+			}
+		}
+	}
+	// Decode query: filter.
+	{
+		values, ok := queryArgs["filter"]
+		if ok {
+			d := uri.NewQueryDecoder(uri.QueryDecoderConfig{
+				Values:  values,
+				Style:   uri.QueryStyleForm,
+				Explode: true,
+			})
+
+			if err := func() error {
+				var paramsDotFilterVal string
+				if err := func() error {
+					s, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(s)
+					if err != nil {
+						return err
+					}
+
+					paramsDotFilterVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.Filter.SetTo(paramsDotFilterVal)
+				return nil
+			}(); err != nil {
+				return params, errors.Wrap(err, "query: filter: parse")
+			}
+		}
+	}
 	return params, nil
 }
 
@@ -664,6 +944,76 @@ func decodeListPetFriendsParams(args [1]string, r *http.Request) (ListPetFriends
 			}
 		}
 	}
+	// Decode query: orderBy.
+	{
+		values, ok := queryArgs["orderBy"]
+		if ok {
+			d := uri.NewQueryDecoder(uri.QueryDecoderConfig{
+				Values:  values,
+				Style:   uri.QueryStyleForm,
+				Explode: true,
+			})
+
+			if err := func() error {
+				var paramsDotOrderByVal string
+				if err := func() error {
+					s, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(s)
+					if err != nil {
+						return err
+					}
+
+					paramsDotOrderByVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.OrderBy.SetTo(paramsDotOrderByVal)
+				return nil
+			}(); err != nil {
+				return params, errors.Wrap(err, "query: orderBy: parse")
+			}
+		}
+	}
+	// Decode query: filter.
+	{
+		values, ok := queryArgs["filter"]
+		if ok {
+			d := uri.NewQueryDecoder(uri.QueryDecoderConfig{
+				Values:  values,
+				Style:   uri.QueryStyleForm,
+				Explode: true,
+			})
+
+			if err := func() error {
+				var paramsDotFilterVal string
+				if err := func() error {
+					s, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(s)
+					if err != nil {
+						return err
+					}
+
+					paramsDotFilterVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.Filter.SetTo(paramsDotFilterVal)
+				return nil
+			}(); err != nil {
+				return params, errors.Wrap(err, "query: filter: parse")
+			}
+		}
+	}
 	return params, nil
 }
 
@@ -739,6 +1089,76 @@ func decodeListUserParams(args [0]string, r *http.Request) (ListUserParams, erro
 				return nil
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: itemsPerPage: parse")
+			}
+		}
+	}
+	// Decode query: orderBy.
+	{
+		values, ok := queryArgs["orderBy"]
+		if ok {
+			d := uri.NewQueryDecoder(uri.QueryDecoderConfig{
+				Values:  values,
+				Style:   uri.QueryStyleForm,
+				Explode: true,
+			})
+
+			if err := func() error {
+				var paramsDotOrderByVal string
+				if err := func() error {
+					s, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(s)
+					if err != nil {
+						return err
+					}
+
+					paramsDotOrderByVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.OrderBy.SetTo(paramsDotOrderByVal)
+				return nil
+			}(); err != nil {
+				return params, errors.Wrap(err, "query: orderBy: parse")
+			}
+		}
+	}
+	// Decode query: filter.
+	{
+		values, ok := queryArgs["filter"]
+		if ok {
+			d := uri.NewQueryDecoder(uri.QueryDecoderConfig{
+				Values:  values,
+				Style:   uri.QueryStyleForm,
+				Explode: true,
+			})
+
+			if err := func() error {
+				var paramsDotFilterVal string
+				if err := func() error {
+					s, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(s)
+					if err != nil {
+						return err
+					}
+
+					paramsDotFilterVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.Filter.SetTo(paramsDotFilterVal)
+				return nil
+			}(); err != nil {
+				return params, errors.Wrap(err, "query: filter: parse")
 			}
 		}
 	}
@@ -848,6 +1268,76 @@ func decodeListUserPetsParams(args [1]string, r *http.Request) (ListUserPetsPara
 				return nil
 			}(); err != nil {
 				return params, errors.Wrap(err, "query: itemsPerPage: parse")
+			}
+		}
+	}
+	// Decode query: orderBy.
+	{
+		values, ok := queryArgs["orderBy"]
+		if ok {
+			d := uri.NewQueryDecoder(uri.QueryDecoderConfig{
+				Values:  values,
+				Style:   uri.QueryStyleForm,
+				Explode: true,
+			})
+
+			if err := func() error {
+				var paramsDotOrderByVal string
+				if err := func() error {
+					s, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(s)
+					if err != nil {
+						return err
+					}
+
+					paramsDotOrderByVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.OrderBy.SetTo(paramsDotOrderByVal)
+				return nil
+			}(); err != nil {
+				return params, errors.Wrap(err, "query: orderBy: parse")
+			}
+		}
+	}
+	// Decode query: filter.
+	{
+		values, ok := queryArgs["filter"]
+		if ok {
+			d := uri.NewQueryDecoder(uri.QueryDecoderConfig{
+				Values:  values,
+				Style:   uri.QueryStyleForm,
+				Explode: true,
+			})
+
+			if err := func() error {
+				var paramsDotFilterVal string
+				if err := func() error {
+					s, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(s)
+					if err != nil {
+						return err
+					}
+
+					paramsDotFilterVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.Filter.SetTo(paramsDotFilterVal)
+				return nil
+			}(); err != nil {
+				return params, errors.Wrap(err, "query: filter: parse")
 			}
 		}
 	}

--- a/internal/integration/ogent/ent/ogent/oas_param_gen.go
+++ b/internal/integration/ogent/ent/ogent/oas_param_gen.go
@@ -90,6 +90,10 @@ type ListCategoryParams struct {
 	Page OptInt
 	// Item count to render per page.
 	ItemsPerPage OptInt
+	// Clause is used to sort the records in the result set for a SELECT statement.
+	OrderBy OptString
+	// Text strings that you use to specify a subset of the data items.
+	Filter OptString
 }
 
 type ListCategoryPetsParams struct {
@@ -99,6 +103,10 @@ type ListCategoryPetsParams struct {
 	Page OptInt
 	// Item count to render per page.
 	ItemsPerPage OptInt
+	// Clause is used to sort the records in the result set for a SELECT statement.
+	OrderBy OptString
+	// Text strings that you use to specify a subset of the data items.
+	Filter OptString
 }
 
 type ListPetParams struct {
@@ -106,6 +114,10 @@ type ListPetParams struct {
 	Page OptInt
 	// Item count to render per page.
 	ItemsPerPage OptInt
+	// Clause is used to sort the records in the result set for a SELECT statement.
+	OrderBy OptString
+	// Text strings that you use to specify a subset of the data items.
+	Filter OptString
 }
 
 type ListPetCategoriesParams struct {
@@ -115,6 +127,10 @@ type ListPetCategoriesParams struct {
 	Page OptInt
 	// Item count to render per page.
 	ItemsPerPage OptInt
+	// Clause is used to sort the records in the result set for a SELECT statement.
+	OrderBy OptString
+	// Text strings that you use to specify a subset of the data items.
+	Filter OptString
 }
 
 type ListPetFriendsParams struct {
@@ -124,6 +140,10 @@ type ListPetFriendsParams struct {
 	Page OptInt
 	// Item count to render per page.
 	ItemsPerPage OptInt
+	// Clause is used to sort the records in the result set for a SELECT statement.
+	OrderBy OptString
+	// Text strings that you use to specify a subset of the data items.
+	Filter OptString
 }
 
 type ListUserParams struct {
@@ -131,6 +151,10 @@ type ListUserParams struct {
 	Page OptInt
 	// Item count to render per page.
 	ItemsPerPage OptInt
+	// Clause is used to sort the records in the result set for a SELECT statement.
+	OrderBy OptString
+	// Text strings that you use to specify a subset of the data items.
+	Filter OptString
 }
 
 type ListUserPetsParams struct {
@@ -140,6 +164,10 @@ type ListUserPetsParams struct {
 	Page OptInt
 	// Item count to render per page.
 	ItemsPerPage OptInt
+	// Clause is used to sort the records in the result set for a SELECT statement.
+	OrderBy OptString
+	// Text strings that you use to specify a subset of the data items.
+	Filter OptString
 }
 
 type ReadCategoryParams struct {

--- a/internal/integration/ogent/ent/ogent/ogent.go
+++ b/internal/integration/ogent/ent/ogent/ogent.go
@@ -35,6 +35,50 @@ func rawError(err error) jx.Raw {
 	return e.Bytes()
 }
 
+var (
+	PrivIdCreateCategory int
+
+	PrivIdReadCategory int
+
+	PrivIdUpdateCategory int
+
+	PrivIdDeleteCategory int
+
+	PrivIdListCategory int
+
+	PrivIdListCategoryPets int
+
+	PrivIdCreatePet int
+
+	PrivIdDeletePet int
+
+	PrivIdListPet int
+
+	PrivIdReadPet int
+
+	PrivIdUpdatePet int
+
+	PrivIdListPetCategories int
+
+	PrivIdReadPetOwner int
+
+	PrivIdListPetFriends int
+
+	PrivIdCreateUser int
+
+	PrivIdReadUser int
+
+	PrivIdUpdateUser int
+
+	PrivIdDeleteUser int
+
+	PrivIdListUser int
+
+	PrivIdListUserPets int
+
+	PrivIdReadUserBestFriend int
+)
+
 type Boolean bool
 
 func (b *Boolean) Capture(values []string) error {
@@ -336,6 +380,11 @@ var (
 		participle.CaseInsensitive("Keyword"),
 	)
 )
+
+func (h *OgentHandler) PolicyForRequest(ctx context.Context, r *http.Request) Policy{
+
+	return nil
+}
 
 // CreateCategory handles POST /categories requests.
 func (h *OgentHandler) CreateCategory(ctx context.Context, req CreateCategoryReq) (CreateCategoryRes, error) {

--- a/internal/integration/ogent/ent/openapi.json
+++ b/internal/integration/ogent/ent/openapi.json
@@ -30,6 +30,22 @@
             "schema": {
               "type": "integer"
             }
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "description": "clause is used to sort the records in the result set for a SELECT statement.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "text strings that you use to specify a subset of the data items",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -294,6 +310,22 @@
             "schema": {
               "type": "integer"
             }
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "description": "clause is used to sort the records in the result set for a SELECT statement.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "text strings that you use to specify a subset of the data items",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -348,6 +380,22 @@
             "description": "item count to render per page",
             "schema": {
               "type": "integer"
+            }
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "description": "clause is used to sort the records in the result set for a SELECT statement.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "text strings that you use to specify a subset of the data items",
+            "schema": {
+              "type": "string"
             }
           }
         ],
@@ -646,6 +694,22 @@
             "schema": {
               "type": "integer"
             }
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "description": "clause is used to sort the records in the result set for a SELECT statement.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "text strings that you use to specify a subset of the data items",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -709,6 +773,22 @@
             "description": "item count to render per page",
             "schema": {
               "type": "integer"
+            }
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "description": "clause is used to sort the records in the result set for a SELECT statement.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "text strings that you use to specify a subset of the data items",
+            "schema": {
+              "type": "string"
             }
           }
         ],
@@ -809,6 +889,22 @@
             "description": "item count to render per page",
             "schema": {
               "type": "integer"
+            }
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "description": "clause is used to sort the records in the result set for a SELECT statement.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "text strings that you use to specify a subset of the data items",
+            "schema": {
+              "type": "string"
             }
           }
         ],
@@ -1182,6 +1278,22 @@
             "description": "item count to render per page",
             "schema": {
               "type": "integer"
+            }
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "description": "clause is used to sort the records in the result set for a SELECT statement.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "text strings that you use to specify a subset of the data items",
+            "schema": {
+              "type": "string"
             }
           }
         ],

--- a/template/create.tmpl
+++ b/template/create.tmpl
@@ -1,6 +1,7 @@
 {{ define "ogent/ogent/helper/create" }}{{/* gotype: entgo.io/ent/entc/gen.Type */}}
+	p := GetPolicyFromContext(ctx)
 	b := h.client.{{ $.Name }}.Create()
-	// Add all fields.
+	// Add all fields.!
 	{{- range $f := $.Fields }}
 		{{- if $f.Optional }}
 			if v, ok := req.{{ $f.StructField}}.Get(); ok {
@@ -11,7 +12,9 @@
 		{{- else }}
 			{{- $x := print "req." $f.StructField }}
 			{{- if $f.IsEnum }}{{ $x = convertTo $f.Type.String $x }}{{ end }}
-			b.Set{{ $f.StructField }}({{ $x }})
+			if p.IsAllowed(PrivIdCreate{{ $.Name }}Req{{ $f.StructField }}) {
+				b.Set{{ $f.StructField }}({{ $x }})
+			}
 		{{- end }}
 	{{- end }}
 	// Add all edges.
@@ -20,7 +23,7 @@
 			b.{{ $e.MutationAdd }}(req.{{ $e.StructField }}...)
 		{{- else }}
 			{{- if $e.Optional }}
-				if v, ok := req.{{ $e.StructField }}.Get(); ok {
+				if v, ok := req.{{ $e.StructField }}.Get(); ok && !p.IsAllowed(PrivIdCreate{{ $.Name }}Req{{ $e.StructField }}){
 					b.{{ $e.MutationSet }}(v)
 				}
 			{{- else }}
@@ -46,5 +49,27 @@
 		// This should never happen.
 		return nil, err
 	}
-	return New{{ viewName $ "create"  }}(e), nil
+	r := New{{ viewName $ "create"  }}(e)
+	if r == nil{
+		return nil, nil
+	}
+	v := &{{ viewName $ "create"  }}{}
+	v.ID = r.ID
+	{{- range $f := $.Fields }}
+		{{- if $f.Optional }}
+			if v, ok := req.{{ $f.StructField}}.Get(); ok {
+				{{- $x := "v" }}
+				{{- if $f.IsEnum }}{{ $x = convertTo $f.Type.String $x }}{{ end }}
+				v.{{ $f.StructField }} = r.{{ $f.StructField }}
+			}
+		{{- else }}
+			{{- $x := print "req." $f.StructField }}
+			{{- if $f.IsEnum }}{{ $x = convertTo $f.Type.String $x }}{{ end }}
+			if p.IsAllowed(PrivIdCreate{{ $.Name }}Res{{ $f.StructField }}) {
+				v.{{ $f.StructField }} = r.{{ $f.StructField }}
+		}
+		{{- end }}
+	{{- end }}
+	return v, nil
+
 {{- end }}

--- a/template/handler.tmpl
+++ b/template/handler.tmpl
@@ -26,6 +26,8 @@
 		return e.Bytes()
 	}
 
+	{{- template "ogent/ogent/helper/list-filter" -}}
+
 	{{- range $n := $.Nodes }}
 		{{- $root := print "/" ($n.Name | plural | kebab) }}
 		{{- range $op := nodeOperations $n }}
@@ -48,6 +50,7 @@
 					panic("unimplemented")
 				{{- end }}
 			}
+
 		{{ end }}
 		{{- range $e := $n.Edges }}
 			{{- range $op := edgeOperations $e }}
@@ -62,3 +65,4 @@
 		{{ end }}
 	{{ end }}
 {{ end }}
+

--- a/template/handler.tmpl
+++ b/template/handler.tmpl
@@ -16,8 +16,47 @@
 		client *{{ $pkg }}.Client
 	}
 
+	type PolicyIdProvider interface {
+		GetPrivId(value ...string) int
+	}
+
+	type PolicyInit struct{
+		policy sync.Once
+	}
+
+	func (f *PolicyInit) Init(p PolicyIdProvider) {
+		f.policy.Do(func() {
+			{{- range $n := $.Nodes }}
+				{{- range $op := nodeOperations $n }}
+					{{- $opID := print ($op | toString | pascal) $n.Name }}
+					// {{ $opID }}
+					PrivId{{ $opID }} = p.GetPrivId("{{ $op }}", "{{ lower $n.Name }}")
+					{{- range $f := $n.Fields }}
+						PrivId{{ $opID }}Req{{ $f.StructField }} = p.GetPrivId("{{ $op }}", "{{lower $n.Name }}", "req", "{{lower $f.StructField }}")
+						PrivId{{ $opID }}Res{{ $f.StructField }} = p.GetPrivId("{{ $op }}", "{{lower $n.Name }}", "res", "{{lower $f.StructField }}")
+					{{- end }}
+					{{- range $e := $n.Edges }}
+						PrivId{{ $opID }}Req{{ $e.StructField }} = p.GetPrivId("{{ $op }}", "{{lower $n.Name }}", "req", "{{lower $e.StructField }}")
+						PrivId{{ $opID }}Res{{ $e.StructField }} = p.GetPrivId("{{ $op }}", "{{lower $n.Name }}", "res", "{{lower $e.StructField }}")
+					{{- end }}
+				{{- end }}
+				{{- range $e := $n.Edges }}
+					{{- range $op := edgeOperations $e }}
+						{{- if or (isRead $op) (isList $op) }}
+							{{- $opID := print ($op | toString | pascal) $n.Name ($e.Name | pascal) }}
+							// {{ $opID }}
+							PrivId{{ $opID }} = p.GetPrivId("{{ $op }}", "{{lower $n.Name }}", "{{lower $e.Name }}")
+						{{- end }}
+					{{ end }}
+				{{ end }}
+			{{ end }}
+		})
+	}
+
 	// NewOgentHandler returns a new OgentHandler.
-	func NewOgentHandler(c *{{ $pkg }}.Client) *OgentHandler { return &OgentHandler{c} }
+	func NewOgentHandler(c *{{ $pkg }}.Client) *OgentHandler {
+		return &OgentHandler{c}
+	}
 
 	// rawError renders err as json string.
 	func rawError(err error) jx.Raw {
@@ -25,6 +64,33 @@
 		e.Str(err.Error())
 		return e.Bytes()
 	}
+
+	var (
+	{{- range $n := $.Nodes }}
+		{{- range $op := nodeOperations $n }}
+			{{- $opID := print ($op | toString | pascal) $n.Name }}
+			// {{ $opID }}
+			PrivId{{ $opID }} int
+			{{- range $f := $n.Fields }}
+				PrivId{{ $opID }}Req{{ $f.StructField }} int
+				PrivId{{ $opID }}Res{{ $f.StructField }} int
+			{{- end }}
+			{{- range $e := $n.Edges }}
+				PrivId{{ $opID }}Req{{ $e.StructField }} int
+				PrivId{{ $opID }}Res{{ $e.StructField }} int
+			{{- end }}
+		{{- end }}
+		{{- range $e := $n.Edges }}
+			{{- range $op := edgeOperations $e }}
+				{{- if or (isRead $op) (isList $op) }}
+					{{- $opID := print ($op | toString | pascal) $n.Name ($e.Name | pascal) }}
+					// {{ $opID }}
+					PrivId{{ $opID }} int
+				{{- end }}
+			{{ end }}
+		{{ end }}
+	{{ end }}
+	)
 
 	{{- template "ogent/ogent/helper/list-filter" -}}
 

--- a/template/handler.tmpl
+++ b/template/handler.tmpl
@@ -17,7 +17,7 @@
 	}
 
 	type PolicyIdProvider interface {
-		GetPrivId(value ...string) int
+		GetPrivId(value string) int
 	}
 
 	type PolicyInit struct{
@@ -30,14 +30,14 @@
 				{{- range $op := nodeOperations $n }}
 					{{- $opID := print ($op | toString | pascal) $n.Name }}
 					// {{ $opID }}
-					PrivId{{ $opID }} = p.GetPrivId("{{ $op }}", "{{ lower $n.Name }}")
+					PrivId{{ $opID }} = p.GetPrivId("{{ $op }} {{ lower $n.Name }}")
 					{{- range $f := $n.Fields }}
-						PrivId{{ $opID }}Req{{ $f.StructField }} = p.GetPrivId("{{ $op }}", "{{lower $n.Name }}", "req", "{{lower $f.StructField }}")
-						PrivId{{ $opID }}Res{{ $f.StructField }} = p.GetPrivId("{{ $op }}", "{{lower $n.Name }}", "res", "{{lower $f.StructField }}")
+						PrivId{{ $opID }}Req{{ $f.StructField }} = p.GetPrivId("{{ $op }} {{lower $n.Name }} req {{lower $f.StructField }}")
+						PrivId{{ $opID }}Res{{ $f.StructField }} = p.GetPrivId("{{ $op }} {{lower $n.Name }} res {{lower $f.StructField }}")
 					{{- end }}
 					{{- range $e := $n.Edges }}
-						PrivId{{ $opID }}Req{{ $e.StructField }} = p.GetPrivId("{{ $op }}", "{{lower $n.Name }}", "req", "{{lower $e.StructField }}")
-						PrivId{{ $opID }}Res{{ $e.StructField }} = p.GetPrivId("{{ $op }}", "{{lower $n.Name }}", "res", "{{lower $e.StructField }}")
+						PrivId{{ $opID }}Req{{ $e.StructField }} = p.GetPrivId("{{ $op }} {{lower $n.Name }} req {{lower $e.StructField }}")
+						PrivId{{ $opID }}Res{{ $e.StructField }} = p.GetPrivId("{{ $op }} {{lower $n.Name }} res {{lower $e.StructField }}")
 					{{- end }}
 				{{- end }}
 				{{- range $e := $n.Edges }}
@@ -45,7 +45,7 @@
 						{{- if or (isRead $op) (isList $op) }}
 							{{- $opID := print ($op | toString | pascal) $n.Name ($e.Name | pascal) }}
 							// {{ $opID }}
-							PrivId{{ $opID }} = p.GetPrivId("{{ $op }}", "{{lower $n.Name }}", "{{lower $e.Name }}")
+							PrivId{{ $opID }} = p.GetPrivId("{{ $op }} {{lower $n.Name }} {{lower $e.Name }}")
 						{{- end }}
 					{{ end }}
 				{{ end }}

--- a/template/list-filter.tmpl
+++ b/template/list-filter.tmpl
@@ -1,0 +1,242 @@
+{{ define "ogent/ogent/helper/list-filter" }}{{/* gotype: entgo.io/ent/entc/gen.Type */}}
+
+type Boolean bool
+
+func (b *Boolean) Capture(values []string) error {
+    *b = values[0] == "TRUE"
+    return nil
+}
+
+type Select struct {
+    Top        *Term             `"SELECT" [ "TOP" @@ ]`
+    Distinct   bool              `[  @"DISTINCT"`
+    All        bool              ` | @"ALL" ]`
+    Expression *SelectExpression `@@`
+    From       *From             `"FROM" @@`
+    Limit      *Expression       `[ "LIMIT" @@ ]`
+    Offset     *Expression       `[ "OFFSET" @@ ]`
+    GroupBy    *Expression       `[ "GROUP" "BY" @@ ]`
+}
+
+type From struct {
+    TableExpressions []*TableExpression `@@ { "," @@ }`
+    Where            *Expression        `[ "WHERE" @@ ]`
+}
+
+type TableExpression struct {
+    Table  string        `( @Ident { "." @Ident }`
+    Select *Select       `  | "(" @@ ")"`
+    Values []*Expression `  | "VALUES" "(" @@ { "," @@ } ")")`
+    As     string        `[ "AS" @Ident ]`
+}
+
+type SelectExpression struct {
+    All         bool                 `  @"*"`
+    Expressions []*AliasedExpression `| @@ { "," @@ }`
+}
+
+type AliasedExpression struct {
+    Expression *Expression `@@`
+    As         string      `[ "AS" @Ident ]`
+}
+
+type Expression struct {
+    Or []*OrCondition `@@ { "or" @@ }`
+}
+
+type OrCondition struct {
+    And []*Condition `@@ { "and" @@ }`
+}
+
+type Condition struct {
+    Operand *ConditionOperand `  @@`
+    Not     *Condition        `| "NOT" @@`
+    Exists  *Select           `| "EXISTS" "(" @@ ")"`
+}
+
+type ConditionOperand struct {
+    Operand      *Operand      `@@`
+    ConditionRHS *ConditionRHS `[ @@ ]`
+}
+
+type ConditionRHS struct {
+    Compare *Compare `  @@`
+    Is      *Is      `| "IS" @@`
+    Between *Between `| "BETWEEN" @@`
+    In      *In      `| "IN" "(" @@ ")"`
+    Like    *Like    `| "LIKE" @@`
+}
+
+type Compare struct {
+    Operator string         `@( "ne" | "le" | "ge" | "eq" | "lt" | "gt")`
+    Operand  *Operand       `(  @@`
+    Select   *CompareSelect ` | @@ )`
+}
+
+type CompareSelect struct {
+    All    bool    `(  @"ALL"`
+    Any    bool    ` | @"ANY"`
+    Some   bool    ` | @"SOME" )`
+    Select *Select `"(" @@ ")"`
+}
+
+type Like struct {
+    Not     bool     `[ @"NOT" ]`
+    Operand *Operand `@@`
+}
+
+type Is struct {
+    Not          bool     `[ @"NOT" ]`
+    Null         bool     `( @"NULL"`
+    DistinctFrom *Operand `  | "DISTINCT" "FROM" @@ )`
+}
+
+type Between struct {
+    Start *Operand `@@`
+    End   *Operand `"and" @@`
+}
+
+type In struct {
+    Select      *Select       `  @@`
+    Expressions []*Expression `| @@ { "," @@ }`
+}
+
+type Operand struct {
+    Summand []*Summand `@@ { "|" "|" @@ }`
+}
+
+type Summand struct {
+    LHS *Factor `@@`
+    Op  string  `[ @("+" | "-")`
+    RHS *Factor `  @@ ]`
+}
+
+type Factor struct {
+    LHS *Term  `@@`
+    Op  string `[ @("*" | "/" | "%")`
+    RHS *Term  `  @@ ]`
+}
+
+type Term struct {
+    Select        *Select     `  @@`
+    Value         *Value      `| @@`
+    SymbolRef     *SymbolRef  `| @@`
+    SubExpression *Expression `| "(" @@ ")"`
+}
+
+type SymbolRef struct {
+    Symbol     string        `@Ident @{ "." Ident }`
+    Parameters []*Expression `[ "(" @@ { "," @@ } ")" ]`
+}
+
+type Value struct {
+    Wildcard bool       `(  @"*"`
+    Number   *float64   ` | @Number`
+    String   *string    ` | @String`
+    Boolean  *Boolean   ` | @("TRUE" | "FALSE")`
+    Null     bool       ` | @"NULL"`
+    Date     *time.Time ` | @Date`
+    Array    *Array     ` | @@ )`
+}
+
+type Array struct {
+    Expressions []*Expression `"(" @@ { "," @@ } ")"`
+}
+
+
+func ParseExpression(exp *Expression, s *sql.Selector) {
+    i := 0
+    len := len(exp.Or)
+    for i < len { //OR
+        parseAndExpression(exp.Or[i], s)
+        i++
+        if i < len {
+            s.Or()
+        }
+    }
+}
+
+func parseAndExpression(and *OrCondition, s *sql.Selector) {
+    for _, c := range and.And {
+        if c.Operand != nil{
+            addPredicate(c, s)
+        }else if c.Not != nil {
+            addPredicate(c.Not, s)
+        }
+    }
+}
+
+func addPredicate(c *Condition, s *sql.Selector){
+    con := c.Operand.ConditionRHS
+    if con != nil{
+    op := con.Compare.Operator
+    col := getColumn(c.Operand)
+    v := getOperand(c.Operand.ConditionRHS.Compare.Operand, s)
+    switch op {
+    case "eq":
+        s.Where(sql.EQ(s.C(col), v)) //Equal
+    case "ne":
+        s.Where(sql.NEQ(s.C(col), v)) //Not equal
+    case "gt":
+        s.Where(sql.GT(s.C(col), v)) //Greater than
+    case "ge":
+        s.Where(sql.GTE(s.C(col), v)) //Greater than or equal
+    case "lt":
+        s.Where(sql.LT(s.C(col), v)) //Less than
+    case "le":
+        s.Where(sql.LTE(s.C(col), v)) //Less than or equal
+    }
+    }else{
+        v := getOperand(c.Operand.Operand, s).(*Array)
+        for _, i := range v.Expressions{
+            ParseExpression(i, s)
+        }
+    }
+}
+
+func getColumn(col *ConditionOperand) string {
+    return getOperand(col.Operand, nil).(string)
+}
+
+func getOperand(op *Operand, s *sql.Selector) interface{} {
+    for _, su := range op.Summand {
+        return getValue(su, s)
+    }
+    return nil
+}
+
+func getValue(su *Summand, s *sql.Selector) interface{} {
+    if su.LHS.LHS.Value != nil {
+        v := su.LHS.LHS.Value
+    if v.String != nil {
+        return v.String
+    } else if v.Number != nil {
+        return v.Number
+    } else if v.Date != nil {
+        return v.Date
+    }else if v.Array != nil {
+        return v.Array
+    }
+    } else {
+        return su.LHS.LHS.SymbolRef.Symbol
+    }
+    return nil
+}
+
+var (
+    sqlLexer = lexer.Must(lexer.Regexp(`(\s+)` +
+    `|(?P<Keyword>(?i)SELECT|FROM|TOP|DISTINCT|ALL|WHERE|GROUP|BY|HAVING|UNION|MINUS|EXCEPT|INTERSECT|ORDER|LIMIT|OFFSET|TRUE|FALSE|NULL|IS|NOT|ANY|SOME|BETWEEN|and|or|LIKE|AS|IN)` +
+    `|(?P<Ident>[a-zA-Z_][a-zA-Z0-9_]*)` +
+    `|(?P<Date>\d{4})-(\d{2})-(\d{2})[tT](\d{2}):(\d{2}):(\d{2})(\.\d+)?([zZ]|(\+|-)(\d{2}):(\d{2}))` +
+    `|(?P<Number>[-+]?\d*\.?\d+([eE][-+]?\d+)?)` +
+    `|(?P<String>'[^']*'|"[^"]*")` +
+    `|(?P<Operators><>|!=|<=|>=|[-+*/%,.()=<>]|eq|ne|gt|ge|lt|le)`,
+    ))
+    SqlParser = participle.MustBuild(
+    &Expression{},
+    participle.Lexer(sqlLexer),
+    participle.Unquote("String"),
+    participle.CaseInsensitive("Keyword"),
+    )
+)
+{{- end }}

--- a/template/list-filter.tmpl
+++ b/template/list-filter.tmpl
@@ -143,59 +143,121 @@ type Array struct {
     Expressions []*Expression `"(" @@ { "," @@ } ")"`
 }
 
+type ValidationError struct {
+    Name string // Field or edge name.
+    err  error
+}
 
-func ParseExpression(exp *Expression, s *sql.Selector) {
+// Error implements the error interface.
+func (e *ValidationError) Error() string {
+    return e.err.Error()
+}
+
+// Unwrap implements the errors.Wrapper interface.
+func (e *ValidationError) Unwrap() error {
+    return e.err
+}
+
+type PredicateNotFound struct {
+    Name string // Field or edge name.
+    err  error
+}
+
+// Error implements the error interface.
+func (e *PredicateNotFound) Error() string {
+    return e.err.Error()
+}
+
+// Unwrap implements the errors.Wrapper interface.
+func (e *PredicateNotFound) Unwrap() error {
+    return e.err
+}
+
+func createColumnMap(col []string) map[string]bool {
+    columnsMap := make(map[string]bool)
+    for i := 0; i < len(col); i += 1 {
+        columnsMap[col[i]] = true
+    }
+    return columnsMap
+}
+
+func ParseExpression(exp *Expression, s *sql.Selector, cols map[string]bool) error {
     i := 0
-    len := len(exp.Or)
-    for i < len { //OR
-        parseAndExpression(exp.Or[i], s)
+    size := len(exp.Or)
+    for i < size { //OR
+        parseAndExpression(exp.Or[i], s, cols)
         i++
-        if i < len {
-            s.Or()
+        if i < size {
+            s.Or() //OR Operator
         }
     }
+    return nil
 }
 
-func parseAndExpression(and *OrCondition, s *sql.Selector) {
+func parseAndExpression(and *OrCondition, s *sql.Selector, cols map[string]bool) {
     for _, c := range and.And {
-        if c.Operand != nil{
-            addPredicate(c, s)
-        }else if c.Not != nil {
-            addPredicate(c.Not, s)
+        if c.Operand != nil { // And Operator
+            con := c.Operand.ConditionRHS
+            if con != nil {
+                col := getColumn(c)
+                if !cols[col] { //check if column is valid
+                    s.AddError(&ValidationError{Name: col, err: fmt.Errorf("ogent: invalid field %q for query", col)})
+                }
+                addPredicate(c, s, col)
+            } else {
+                recursiveOperation(c, s, cols)
+            }
+        } else if c.Not != nil { // Not Operator
+                col := getColumn(c)
+                if !cols[col] { //check if column is valid
+                    s.AddError(&ValidationError{Name: col, err: fmt.Errorf("ogent: invalid field %q for query", col)})
+                }
+                s.Not()
+                addPredicate(c.Not, s, col)
         }
     }
 }
 
-func addPredicate(c *Condition, s *sql.Selector){
+func recursiveOperation(c *Condition, s *sql.Selector, cols map[string]bool) {
+    v := getOperand(c.Operand.Operand, s).(*Array)
+    for _, i := range v.Expressions {
+        ParseExpression(i, s, cols)
+    }
+}
+
+func getColumn(c *Condition) string {
+    if c.Operand != nil {
+        if c.Operand.ConditionRHS != nil {
+            return getOperand(c.Operand.Operand, nil).(string)
+        }
+    } else {
+        return getOperand(c.Not.Operand.Operand, nil).(string)
+    }
+    return ""
+}
+
+func addPredicate(c *Condition, s *sql.Selector, col string){
     con := c.Operand.ConditionRHS
-    if con != nil{
-    op := con.Compare.Operator
-    col := getColumn(c.Operand)
-    v := getOperand(c.Operand.ConditionRHS.Compare.Operand, s)
-    switch op {
-    case "eq":
-        s.Where(sql.EQ(s.C(col), v)) //Equal
-    case "ne":
-        s.Where(sql.NEQ(s.C(col), v)) //Not equal
-    case "gt":
-        s.Where(sql.GT(s.C(col), v)) //Greater than
-    case "ge":
-        s.Where(sql.GTE(s.C(col), v)) //Greater than or equal
-    case "lt":
-        s.Where(sql.LT(s.C(col), v)) //Less than
-    case "le":
-        s.Where(sql.LTE(s.C(col), v)) //Less than or equal
-    }
-    }else{
-        v := getOperand(c.Operand.Operand, s).(*Array)
-        for _, i := range v.Expressions{
-            ParseExpression(i, s)
+    if con != nil {
+        op := con.Compare.Operator
+        v := getOperand(c.Operand.ConditionRHS.Compare.Operand, s)
+        switch op {
+        case "eq":
+            s.Where(sql.EQ(s.C(col), v)) //Equal
+        case "ne":
+            s.Where(sql.NEQ(s.C(col), v)) //Not equal
+        case "gt":
+            s.Where(sql.GT(s.C(col), v)) //Greater than
+        case "ge":
+            s.Where(sql.GTE(s.C(col), v)) //Greater than or equal
+        case "lt":
+            s.Where(sql.LT(s.C(col), v)) //Less than
+        case "le":
+            s.Where(sql.LTE(s.C(col), v)) //Less than or equal
+        default:
+            s.AddError(&PredicateNotFound{Name: col, err: fmt.Errorf("ogent: predicate not found %q for query", op)})
         }
     }
-}
-
-func getColumn(col *ConditionOperand) string {
-    return getOperand(col.Operand, nil).(string)
 }
 
 func getOperand(op *Operand, s *sql.Selector) interface{} {
@@ -208,15 +270,15 @@ func getOperand(op *Operand, s *sql.Selector) interface{} {
 func getValue(su *Summand, s *sql.Selector) interface{} {
     if su.LHS.LHS.Value != nil {
         v := su.LHS.LHS.Value
-    if v.String != nil {
-        return v.String
-    } else if v.Number != nil {
-        return v.Number
-    } else if v.Date != nil {
-        return v.Date
-    }else if v.Array != nil {
-        return v.Array
-    }
+        if v.String != nil {
+            return v.String
+        } else if v.Number != nil {
+            return v.Number
+        } else if v.Date != nil {
+            return v.Date
+        } else if v.Array != nil {
+            return v.Array
+        }
     } else {
         return su.LHS.LHS.SymbolRef.Symbol
     }
@@ -225,7 +287,7 @@ func getValue(su *Summand, s *sql.Selector) interface{} {
 
 var (
     sqlLexer = lexer.Must(lexer.Regexp(`(\s+)` +
-    `|(?P<Keyword>(?i)SELECT|FROM|TOP|DISTINCT|ALL|WHERE|GROUP|BY|HAVING|UNION|MINUS|EXCEPT|INTERSECT|ORDER|LIMIT|OFFSET|TRUE|FALSE|NULL|IS|NOT|ANY|SOME|BETWEEN|and|or|LIKE|AS|IN)` +
+    `|(?P<Keyword>(?i)SELECT|FROM|TOP|DISTINCT|ALL|WHERE|GROUP|BY|HAVING|UNION|MINUS|EXCEPT|INTERSECT|ORDER|LIMIT|OFFSET|TRUE|FALSE|NULL|NOT|ANY|SOME|BETWEEN|and|or|LIKE|AS)` +
     `|(?P<Ident>[a-zA-Z_][a-zA-Z0-9_]*)` +
     `|(?P<Date>\d{4})-(\d{2})-(\d{2})[tT](\d{2}):(\d{2}):(\d{2})(\.\d+)?([zZ]|(\+|-)(\d{2}):(\d{2}))` +
     `|(?P<Number>[-+]?\d*\.?\d+([eE][-+]?\d+)?)` +
@@ -233,10 +295,12 @@ var (
     `|(?P<Operators><>|!=|<=|>=|[-+*/%,.()=<>]|eq|ne|gt|ge|lt|le)`,
     ))
     SqlParser = participle.MustBuild(
-    &Expression{},
-    participle.Lexer(sqlLexer),
-    participle.Unquote("String"),
-    participle.CaseInsensitive("Keyword"),
+        &Expression{},
+        participle.Lexer(sqlLexer),
+        participle.Unquote("String"),
+        participle.CaseInsensitive("Keyword"),
     )
 )
+
+
 {{- end }}

--- a/template/list.tmpl
+++ b/template/list.tmpl
@@ -20,7 +20,7 @@
 			{{- else }}
 				{{- $x := print "req." $f.StructField }}
 				{{- if $f.IsEnum }}{{ $x = convertTo $f.Type.String $x }}{{ end }}
-				if p.IsAllowed(PrivIdRead{{ $.Name }}Res{{ $f.StructField }}) {
+				if p.IsAllowed(PrivIdList{{ $.Name }}Res{{ $f.StructField }}) {
 					o.{{ $f.StructField }} = c.{{ $f.StructField }}
 				}
 			{{- end }}
@@ -52,7 +52,7 @@
 			{{- else }}
 				{{- $x := print "req." $f.StructField }}
 				{{- if $f.IsEnum }}{{ $x = convertTo $f.Type.String $x }}{{ end }}
-				if p.IsAllowed(PrivIdRead{{ $.Scope.Edge.Type.Name }}Res{{ $f.StructField }}) {
+				if p.IsAllowed(PrivIdList{{ $.Scope.Edge.Type.Name }}Res{{ $f.StructField }}) {
 					o.{{ $f.StructField }} = c.{{ $f.StructField }}
 				}
 			{{- end }}

--- a/template/list.tmpl
+++ b/template/list.tmpl
@@ -1,6 +1,8 @@
 {{ define "ogent/ogent/helper/list" }}{{/* gotype: entgo.io/ent/entc/gen.Type */}}
 	q := h.client.{{ $.Name }}.Query(){{ with eagerLoad $ "list" }}{{ . }}{{ end }}
-	{{- template "ogent/ogent/helper/list/paginate-and-filter" $ -}}
+	{{- template "ogent/ogent/helper/list/paginate-and-sort" $ -}}
+	{{- template "ogent/ogent/helper/list/filter" $ -}}
+	{{- template "ogent/ogent/helper/list/execute-query" $ -}}
 	r := New{{ viewName $ "list" | plural }}(es)
 	return (*List{{ $.Name }}OKApplicationJSON)(&r), nil
 {{- end }}
@@ -8,12 +10,13 @@
 {{ define "ogent/ogent/helper/list/sub" }}{{/* gotype: entgo.io/ent/entc/gen.typeScope */}}
 	q := h.client.{{ $.Type.Name }}.Query().Where({{ $.Type.Package }}.IDEQ(params.{{ $.Type.ID.StructField }})).Query{{ $.Scope.Edge.Name | pascal }}()
 	{{- with eagerLoad $.Type "list" }}{{ . }}{{ end }}
-	{{- template "ogent/ogent/helper/list/paginate-and-filter" $.Type -}}
+	{{- template "ogent/ogent/helper/list/paginate-and-sort" $.Type -}}
+	{{- template "ogent/ogent/helper/list/execute-query" $ -}}
 	r := New{{ replaceAll (edgeViewName $.Type $.Scope.Edge "list") "_" "" | plural }}(es)
 	return (*List{{ $.Type.Name }}{{ $.Scope.Edge.Name | pascal }}OKApplicationJSON)(&r), nil
 {{ end }}
 
-{{ define "ogent/ogent/helper/list/paginate-and-filter" }}
+{{ define "ogent/ogent/helper/list/paginate-and-sort" }}
 	page := 1
 	if v, ok := params.Page.Get(); ok {
 		page = v
@@ -22,6 +25,42 @@
 	if v, ok := params.ItemsPerPage.Get(); ok {
 		itemsPerPage = v
 	}
+	//Sort the fetched data in either ascending or descending
+	if v, ok := params.OrderBy.Get(); ok {
+		for _, p := range strings.Split(v, ",") {
+			f := strings.Fields(p)
+			column := f[0]
+			if len(f) > 1 && f[1] == "desc"{
+				q.Order(ent.Desc(column))
+			} else {
+				q.Order(ent.Asc(column))
+			}
+		}
+	}
+{{ end }}
+
+{{ define "ogent/ogent/helper/list/filter" }}
+	//Filter operations
+	if v, ok := params.Filter.Get(); ok {
+		exp := &Expression{}
+		err := SqlParser.ParseString(v, exp)
+		if err != nil {
+			return &R400{
+				Code:   http.StatusBadRequest,
+				Status: http.StatusText(http.StatusBadRequest),
+				Errors: rawError(err),
+			}, nil
+		} else {
+			//parse filter
+			q.Where(func(s *sql.Selector) {
+				ParseExpression(exp, s)
+			})
+		}
+	}
+{{ end }}
+
+{{ define "ogent/ogent/helper/list/execute-query" }}
+	//run the query
 	es, err := q.Limit(itemsPerPage).Offset((page - 1) * itemsPerPage).All(ctx)
 	{{-
 		template "ogent/ogent/helper/error"

--- a/template/list.tmpl
+++ b/template/list.tmpl
@@ -53,7 +53,7 @@
 		} else {
 			//parse filter
 			q.Where(func(s *sql.Selector) {
-				ParseExpression(exp, s)
+				ParseExpression(exp, s, createColumnMap({{lower $.Name}}.Columns))
 			})
 		}
 	}

--- a/template/list.tmpl
+++ b/template/list.tmpl
@@ -1,19 +1,65 @@
 {{ define "ogent/ogent/helper/list" }}{{/* gotype: entgo.io/ent/entc/gen.Type */}}
+	p := GetPolicyFromContext(ctx)
 	q := h.client.{{ $.Name }}.Query(){{ with eagerLoad $ "list" }}{{ . }}{{ end }}
 	{{- template "ogent/ogent/helper/list/paginate-and-sort" $ -}}
 	{{- template "ogent/ogent/helper/list/filter" $ -}}
 	{{- template "ogent/ogent/helper/list/execute-query" $ -}}
-	r := New{{ viewName $ "list" | plural }}(es)
-	return (*List{{ $.Name }}OKApplicationJSON)(&r), nil
+	//Response policy
+	r :=  New{{ viewName $ "list" | plural }}(es)
+    var v []{{ viewName $ "list" }}
+	for _, c := range r {
+		o := {{ viewName $ "list" }}{}
+		o.ID = c.ID
+		{{- range $f := $.Fields }}
+			{{- if $f.Optional }}
+				if v, ok := req.{{ $f.StructField}}.Get(); ok {
+				{{- $x := "v" }}
+				{{- if $f.IsEnum }}{{ $x = convertTo $f.Type.String $x }}{{ end }}
+					o.{{ $f.StructField }} = c.{{ $f.StructField }}
+				}
+			{{- else }}
+				{{- $x := print "req." $f.StructField }}
+				{{- if $f.IsEnum }}{{ $x = convertTo $f.Type.String $x }}{{ end }}
+				if p.IsAllowed(PrivIdRead{{ $.Name }}Res{{ $f.StructField }}) {
+					o.{{ $f.StructField }} = c.{{ $f.StructField }}
+				}
+			{{- end }}
+		{{- end }}
+		v = append(v, o)
+	}
+	return (*List{{ $.Name }}OKApplicationJSON)(&v), nil
 {{- end }}
 
 {{ define "ogent/ogent/helper/list/sub" }}{{/* gotype: entgo.io/ent/entc/gen.typeScope */}}
+	p := GetPolicyFromContext(ctx)
 	q := h.client.{{ $.Type.Name }}.Query().Where({{ $.Type.Package }}.IDEQ(params.{{ $.Type.ID.StructField }})).Query{{ $.Scope.Edge.Name | pascal }}()
 	{{- with eagerLoad $.Type "list" }}{{ . }}{{ end }}
 	{{- template "ogent/ogent/helper/list/paginate-and-sort" $.Type -}}
 	{{- template "ogent/ogent/helper/list/execute-query" $ -}}
+	//Response policy
 	r := New{{ replaceAll (edgeViewName $.Type $.Scope.Edge "list") "_" "" | plural }}(es)
-	return (*List{{ $.Type.Name }}{{ $.Scope.Edge.Name | pascal }}OKApplicationJSON)(&r), nil
+	var v []{{ replaceAll (edgeViewName $.Type $.Scope.Edge "list") "_" "" }}
+	for _, c := range r {
+		o := {{ replaceAll (edgeViewName $.Type $.Scope.Edge "list") "_" "" }}{}
+		o.ID = c.ID
+		{{- range $f := $.Scope.Edge.Type.Fields }}
+			{{- if $f.Optional }}
+				if v, ok := req.{{ $f.StructField}}.Get(); ok {
+					{{- $x := "v" }}
+					{{- if $f.IsEnum }}{{ $x = convertTo $f.Type.String $x }}{{ end }}
+					o.{{ $f.StructField }} = c.{{ $f.StructField }}
+				}
+			{{- else }}
+				{{- $x := print "req." $f.StructField }}
+				{{- if $f.IsEnum }}{{ $x = convertTo $f.Type.String $x }}{{ end }}
+				if p.IsAllowed(PrivIdRead{{ $.Scope.Edge.Type.Name }}Res{{ $f.StructField }}) {
+					o.{{ $f.StructField }} = c.{{ $f.StructField }}
+				}
+			{{- end }}
+		{{- end }}
+		v = append(v, o)
+	}
+	return (*List{{ $.Type.Name }}{{ $.Scope.Edge.Name | pascal }}OKApplicationJSON)(&v), nil
 {{ end }}
 
 {{ define "ogent/ogent/helper/list/paginate-and-sort" }}
@@ -54,6 +100,7 @@
 			//parse filter
 			q.Where(func(s *sql.Selector) {
 				ParseExpression(exp, s, createColumnMap({{lower $.Name}}.Columns))
+				//{{hasPrefix "cat" "catch"}}
 			})
 		}
 	}

--- a/template/read.tmpl
+++ b/template/read.tmpl
@@ -1,6 +1,7 @@
 {{/* gotype: entgo.io/ent/entc/gen.Type */}}
 
 {{ define "ogent/ogent/helper/read" }}
+	p := GetPolicyFromContext(ctx)
 	q := h.client.{{ $.Name }}.Query().Where({{ $.Package }}.IDEQ(params.{{ $.ID.StructField }}))
 	{{- with eagerLoad $ "read" }}{{ . }}{{- end }}
 	e, err := q.Only(ctx)
@@ -9,7 +10,28 @@
 		extend $
 		"Errors" (list "not-found" "not-singular")
 	-}}
-	return New{{ viewName $ "read"  }}(e), nil
+	r := New{{ viewName $ "read"  }}(e)
+	if r == nil{
+		return nil, nil
+	}
+	v := &{{ viewName $ "read"  }}{}
+	v.ID = r.ID
+	{{- range $f := $.Fields }}
+		{{- if $f.Optional }}
+			if v, ok := req.{{ $f.StructField}}.Get(); ok {
+				{{- $x := "v" }}
+				{{- if $f.IsEnum }}{{ $x = convertTo $f.Type.String $x }}{{ end }}
+				v.{{ $f.StructField }} = r.{{ $f.StructField }}
+			}
+		{{- else }}
+			{{- $x := print "req." $f.StructField }}
+			{{- if $f.IsEnum }}{{ $x = convertTo $f.Type.String $x }}{{ end }}
+				if p.IsAllowed(PrivIdRead{{ $.Name }}Req{{ $f.StructField }}) {
+					v.{{ $f.StructField }} = r.{{ $f.StructField }}
+				}
+		{{- end }}
+	{{- end }}
+	return v, nil
 {{- end }}
 
 {{ define "ogent/ogent/helper/read/sub" }}{{/* gotype: entgo.io/ent/entc/gen.typeScope */}}

--- a/template/update.tmpl
+++ b/template/update.tmpl
@@ -1,11 +1,12 @@
 {{/* gotype: entgo.io/ent/entc/gen.Type */}}
 
 {{ define "ogent/ogent/helper/update" }}
+	p := GetPolicyFromContext(ctx)
 	b := h.client.{{ $.Name }}.UpdateOneID(params.{{ $.ID.StructField }})
 	// Add all fields.
 	{{- range $f := $.Fields }}
 		{{- if not $f.Immutable }}
-			if v, ok := req.{{ $f.StructField}}.Get(); ok {
+			if v, ok := req.{{ $f.StructField}}.Get(); ok && p.IsAllowed(PrivIdUpdate{{ $.Name }}Req{{ $f.StructField }}){
 				{{- $x := "v" }}
 				{{- if $f.IsEnum }}{{ $x = convertTo $f.Type.String $x }}{{ end }}
 				b.Set{{ $f.StructField }}({{ $x }})
@@ -17,7 +18,7 @@
 		{{- if not $e.Unique }}
 			b.{{ $e.MutationClear }}().{{ $e.MutationAdd }}(req.{{ $e.StructField }}...)
 		{{- else }}
-			if v, ok := req.{{ $e.StructField }}.Get(); ok {
+			if v, ok := req.{{ $e.StructField }}.Get(); ok && p.IsAllowed(PrivIdUpdate{{ $.Name }}Req{{ $e.StructField }}){
 				b.{{ $e.MutationSet }}(v)
 			}
 		{{- end }}
@@ -40,6 +41,27 @@
 		// This should never happen.
 		return nil, err
 	}
-	return New{{ viewName $ "update"  }}(e), nil
+	r := New{{ viewName $ "update"  }}(e)
+	if r == nil{
+		return nil, nil
+	}
+	v := &{{ viewName $ "update"  }}{}
+	v.ID = r.ID
+	{{- range $f := $.Fields }}
+		{{- if $f.Optional }}
+			if v, ok := req.{{ $f.StructField}}.Get(); ok {
+				{{- $x := "v" }}
+				{{- if $f.IsEnum }}{{ $x = convertTo $f.Type.String $x }}{{ end }}
+				v.{{ $f.StructField }} = r.{{ $f.StructField }}
+			}
+		{{- else }}
+			{{- $x := print "req." $f.StructField }}
+			{{- if $f.IsEnum }}{{ $x = convertTo $f.Type.String $x }}{{ end }}
+				if p.IsAllowed(PrivIdUpdate{{ $.Name }}Req{{ $f.StructField }}) {
+					v.{{ $f.StructField }} = r.{{ $f.StructField }}
+				}
+		{{- end }}
+	{{- end }}
+	return v, nil
 {{- end }}
 


### PR DESCRIPTION
Created two features for Ogent framework.
**OrderBy** The value of the orderBy parameter contains a comma-separated list of expressions used to sort the items. A special case of such an expression is a property path terminating on a primitive property.
eg: `https://api.contoso.com/v1.0/people?orderBy=name` 

**Filter** The filter query string parameter allows clients to filter a collection of resources that are addressed by a request URL. The expression specified with the filter is evaluated for each resource in the collection, and only items where the expression evaluates to true are included in the response. 
eg: `https://api.contoso.com/v1.0/products?filter=name eq 'Milk' and price lt 2.55`

**Important!**
It was necessary to add two new parameters for ENT project. Here is the pull request to be approved by ENT team.
[Added two new parameter to filter and sort a list of models](https://github.com/ent/contrib/pull/271)