### PR TITLE
Fix generated Update endpoints

### DIFF
--- a/internal/integration/ogent/ent/ogent/ogent.go
+++ b/internal/integration/ogent/ent/ogent/ogent.go
@@ -339,7 +339,9 @@ func (h *OgentHandler) UpdateCategory(ctx context.Context, req *UpdateCategoryRe
 		b.SetName(v)
 	}
 	// Add all edges.
-	b.ClearPets().AddPetIDs(req.Pets...)
+	if req.Pets != nil {
+		b.ClearPets().AddPetIDs(req.Pets...)
+	}
 	// Persist to storage.
 	e, err := b.Save(ctx)
 	if err != nil {
@@ -633,11 +635,15 @@ func (h *OgentHandler) UpdatePet(ctx context.Context, req *UpdatePetReq, params 
 		b.SetHeight(v)
 	}
 	// Add all edges.
-	b.ClearCategories().AddCategoryIDs(req.Categories...)
+	if req.Categories != nil {
+		b.ClearCategories().AddCategoryIDs(req.Categories...)
+	}
 	if v, ok := req.Owner.Get(); ok {
 		b.SetOwnerID(v)
 	}
-	b.ClearFriends().AddFriendIDs(req.Friends...)
+	if req.Friends != nil {
+		b.ClearFriends().AddFriendIDs(req.Friends...)
+	}
 	// Persist to storage.
 	e, err := b.Save(ctx)
 	if err != nil {
@@ -868,7 +874,9 @@ func (h *OgentHandler) UpdateUser(ctx context.Context, req *UpdateUserReq, param
 		b.SetFavoriteFishBreed(schema.FishBreed(v))
 	}
 	// Add all edges.
-	b.ClearPets().AddPetIDs(req.Pets...)
+	if req.Pets != nil {
+		b.ClearPets().AddPetIDs(req.Pets...)
+	}
 	if v, ok := req.BestFriend.Get(); ok {
 		b.SetBestFriendID(v)
 	}

--- a/internal/integration/ogent/ogent_test.go
+++ b/internal/integration/ogent/ogent_test.go
@@ -86,7 +86,7 @@ func (t *testSuite) TestUpdate() {
 	// Patch won't clear edges.
 	cat, err := t.client.Category.Create().SetName("dogs").AddPetIDs(pet.ID).Save(context.Background())
 	t.Require().NoError(err)
-	got, err = t.handler.UpdatePet(context.Background(), &ogent.UpdatePetReq{Name: ogent.NewOptString("The again changed name")}, ogent.UpdatePetParams{ID: pet.ID})
+	_, err = t.handler.UpdatePet(context.Background(), &ogent.UpdatePetReq{Name: ogent.NewOptString("The again changed name")}, ogent.UpdatePetParams{ID: pet.ID})
 	t.Require().NoError(err)
 	pets, err := cat.QueryPets().All(context.Background())
 	t.Require().NoError(err)

--- a/internal/integration/ogent/ogent_test.go
+++ b/internal/integration/ogent/ogent_test.go
@@ -82,6 +82,15 @@ func (t *testSuite) TestUpdate() {
 	pet.Name = "The changed name"
 	t.Require().NoError(err)
 	t.Require().Equal(ogent.NewPetUpdate(pet), got)
+
+	// Patch won't clear edges.
+	cat, err := t.client.Category.Create().SetName("dogs").AddPetIDs(pet.ID).Save(context.Background())
+	t.Require().NoError(err)
+	got, err = t.handler.UpdatePet(context.Background(), &ogent.UpdatePetReq{Name: ogent.NewOptString("The again changed name")}, ogent.UpdatePetParams{ID: pet.ID})
+	t.Require().NoError(err)
+	pets, err := cat.QueryPets().All(context.Background())
+	t.Require().NoError(err)
+	t.Require().Len(pets, 1)
 }
 
 func (t *testSuite) TestDelete() {

--- a/template/update.tmpl
+++ b/template/update.tmpl
@@ -25,7 +25,11 @@
 	{{- end }}
 	// Add all edges.
 	{{- range $e := $.Edges }}
-		{{- if $e.Unique }}
+		{{- if not $e.Unique }}
+		    if v, ok := req.{{ $e.StructField }}.Get(); ok {
+			    b.{{ $e.MutationClear }}().{{ $e.MutationAdd }}(req.{{ $e.StructField }}...)
+			}
+		{{- else }}
 			if v, ok := req.{{ $e.StructField }}.Get(); ok {
 				b.{{ $e.MutationSet }}(v)
 			}

--- a/template/update.tmpl
+++ b/template/update.tmpl
@@ -26,7 +26,7 @@
 	// Add all edges.
 	{{- range $e := $.Edges }}
 		{{- if not $e.Unique }}
-			if v, ok := req.{{ $e.StructField }}.Get(); ok {
+			if req.{{ $e.StructField }} != nil {
 			    b.{{ $e.MutationClear }}().{{ $e.MutationAdd }}(req.{{ $e.StructField }}...)
 			}
 		{{- else }}

--- a/template/update.tmpl
+++ b/template/update.tmpl
@@ -26,7 +26,7 @@
 	// Add all edges.
 	{{- range $e := $.Edges }}
 		{{- if not $e.Unique }}
-		    if v, ok := req.{{ $e.StructField }}.Get(); ok {
+			if v, ok := req.{{ $e.StructField }}.Get(); ok {
 			    b.{{ $e.MutationClear }}().{{ $e.MutationAdd }}(req.{{ $e.StructField }}...)
 			}
 		{{- else }}

--- a/template/update.tmpl
+++ b/template/update.tmpl
@@ -25,9 +25,7 @@
 	{{- end }}
 	// Add all edges.
 	{{- range $e := $.Edges }}
-		{{- if not $e.Unique }}
-			b.{{ $e.MutationClear }}().{{ $e.MutationAdd }}(req.{{ $e.StructField }}...)
-		{{- else }}
+		{{- if $e.Unique }}
 			if v, ok := req.{{ $e.StructField }}.Get(); ok {
 				b.{{ $e.MutationSet }}(v)
 			}


### PR DESCRIPTION
This PR fixes #154 in which non-unique edges are cleared in PATCH requests if not specified. The expected behavior is that PATCH with an array replaces the existing members with the PATCH members, but does not change the members of the array if the field is not specified in the PATCH body.