### PR TITLE
use right optional type for date schema

### DIFF
--- a/template.go
+++ b/template.go
@@ -232,8 +232,12 @@ func setFieldExpr(f *gen.Field, schema, rec, ident string) (string, error) {
 		switch t.Format {
 		case Byte:
 			return fmt.Sprintf("%s.%s = %s.%s", rec, f.StructField(), ident, f.StructField()), nil
-		case DateTime, Date, Time:
+		case DateTime:
 			opt = "DateTime"
+		case Date:
+			opt = "Date"
+		case Time:
+			opt = "Time"			
 		case Duration:
 			opt = "Duration"
 		case UUID:


### PR DESCRIPTION
If we define such a field in schema

```go
		field.Time("date").
			SchemaType(map[string]string{
				dialect.Postgres: "date",
			}).
			Annotations(entoas.Schema(ogen.Date())).
			Optional().
			Nillable(),
```

It will report `undefined: OptDateTime` in file `ent/ogent/responses.go `.

This pr is intended to fix this.